### PR TITLE
Ha-mqtt sink plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Source plugins are responsible for collecting data from SMA PV products. These p
 Sink plugins are responsible for publishing the collected data to various output channels. These plugins receive data from the main SMAHub instance and send it to the desired output. Some examples of sink plugins include:
 
 - MQTT: A plugin that publishes data to an MQTT broker, making it easily accessible for home automation systems like Home Assistant.
+- HA-MQTT: A plugin that uses home assistant libraries to publish data directly into home assistant according to ha mqtt sensor semantics
 - gen_ha_sensors: A plugin that generates MQTT sensor definitions of all collected data, for use in Home Assistant configuration.
 
 ## Python

--- a/plugins/sinks/ha_mqtt/README.md
+++ b/plugins/sinks/ha_mqtt/README.md
@@ -1,0 +1,49 @@
+# Home Assistant MQTT Publisher Plugin
+
+The Home Assistant MQTT Publisher Plugin is a SMAHub sink plugin that enables the publishing of SMA device data to a MQTT broker. The data can then be utilized by Home Assistant or any other system that can subscribe to MQTT topics.
+
+## Configuration
+
+The configuration file for the Home Assistant MQTT Publisher plugin is located in the `config` directory and has the following format:
+
+```ini
+[plugin]
+enabled = false
+
+[server]
+address = 192.168.0.1
+username = ""
+password = ""
+
+[behavior]
+# This determines the number of seconds before a full republish of all collected data, even if there's been no value updates
+updatefreq = 60
+sensorprefix = homeassistant
+```
+
+To enable the Home Assistant MQTT Publisher Plugin, set `enabled` to `true`. Under the `[server]` section, provide the MQTT server's `address`, `username`, and `password`. 
+
+The `updatefreq` under the `[behavior]` section determines the frequency (in seconds) at which the plugin republishes all collected data, even if there have been no updates. `sensorprefix` sets the prefix for all sensor topics published to the MQTT broker.
+
+## Environment Variables
+
+The Home Assistant MQTT Publisher plugin can also be configured using the following environment variables:
+
+- `HA_MQTT_ENABLED`: Set to `true` to enable the plugin.
+- `HA_MQTT_ADDRESS`: The address of the MQTT server.
+- `HA_MQTT_USER`: The username for the MQTT server.
+- `HA_MQTT_PASSWORD`: The password for the MQTT server.
+- `HA_MQTT_UPDATEFREQ`: The frequency (in seconds) at which the plugin republishes all collected data.
+- `HA_MQTT_PREFIX`: The prefix for all sensor topics published to the MQTT broker.
+
+## How It Works
+
+The Home Assistant MQTT Publisher plugin works by subscribing to updates from the SMA data dictionary. When an update is received, the plugin publishes the data to the MQTT server.
+
+The plugin also periodically republishes all data from the SMA data dictionary at the configured frequency. This ensures that even if there have been no updates, the current state of all data is periodically pushed to the MQTT server.
+
+The data is published to MQTT topics with the format `<sensorprefix>/<sma_data_key>`, where `<sensorprefix>` is the configured sensor prefix and `<sma_data_key>` is the SMA data key with periods (.) replaced with slashes (/).
+
+The plugin supports both simple values and tuples in the SMA data dictionary. If a value is a tuple, the first element of the tuple is published as the sensor value, and the second element is published as the unit of measurement.
+
+This plugin enables you to easily integrate your SMA devices with Home Assistant or any other system that supports MQTT, providing real-time access to your device data.

--- a/plugins/sinks/ha_mqtt/ha_mqtt.conf
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.conf
@@ -1,0 +1,12 @@
+[plugin]
+enabled = false
+
+[server]
+address = 192.168.0.1
+username = ""
+password = ""
+
+[behavior]
+# this determines the number of seconds before a full republish of all collected data, even if there's been no value updates
+updatefreq = 60
+sensorprefix = homeassistant

--- a/plugins/sinks/ha_mqtt/ha_mqtt.conf
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.conf
@@ -8,5 +8,5 @@ password = ""
 
 [behavior]
 # this determines the number of seconds before a full republish of all collected data, even if there's been no value updates
-updatefreq = 60
+updatefreq = 10
 sensorprefix = homeassistant

--- a/plugins/sinks/ha_mqtt/ha_mqtt.py
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.py
@@ -1,0 +1,107 @@
+import os
+import time
+import logging
+from ha_mqtt_discoverable import Settings
+from ha_mqtt_discoverable.sensors import SensorInfo, Sensor, DeviceInfo
+
+# store for all the ha_mqtt sensor objects
+sensors = {}
+device_infos = {}
+mqtt_settings = {}
+
+def env_vars(config):
+    if os.environ.get('HA_MQTT_ENABLED'):
+        config['plugin']['enabled'] = os.environ.get('HA_MQTT_ENABLED')
+    if os.environ.get('HA_MQTT_ADDRESS'):
+        config['server']['address'] = os.environ.get('HA_MQTT_ADDRESS')
+    if os.environ.get('HA_MQTT_USER'):
+        config['server']['username'] = os.environ.get('HA_MQTT_USER')
+    if os.environ.get('HA_MQTT_PASSWORD'):
+        config['server']['password'] = os.environ.get('HA_MQTT_PASSWORD')
+    if os.environ.get('HA_MQTT_UPDATEFREQ'):
+        config['behavior']['updatefreq'] = int(os.environ.get('HA_MQTT_UPDATEFREQ'))
+    if os.environ.get('HA_MQTT_PREFIX'):
+        config['behavior']['sensorprefix'] = os.environ.get('HA_MQTT_PREFIX')
+
+def execute(config, get_items, register_callback, do_stop):
+    env_vars(config)
+
+    if config.get('plugin', 'enabled').lower() != 'true':
+        logging.info("HA-MQTT sink plugin disabled")
+        return
+
+    logging.info("Starting HA-MQTT sink")
+
+    global mqtt_settings
+    mqtt_settings = Settings.MQTT(host=config['server']['address'], 
+                                username=config['server']['username'], 
+                                password=config['server']['password'],
+                                discovery_prefix=config['server']['sensorprefix'])
+
+    # We only publish data on change
+    register_callback(my_callback)
+
+    i = 0
+    while not do_stop():
+        # while we're normally only publishing on change (see callback below), once a minute (default) push out everything
+        if i%int(config['behavior']['updatefreq']) == 0:
+            # first, retrieve all unique first name-sections from dictionary
+            sma_items = get_items()
+            unique_parts = set()
+            for path in sma_items.keys():
+                first_part = path.split('.')[0]
+                unique_parts.add(first_part)
+
+            for part in unique_parts:
+                # retrieve sub-set of sma_items that contains keys beginning with 'part' (current device)
+                filtered_items = {k: v for k, v in sma_items.items() if k.split('.')[0] == part}
+
+                # create device_info objects
+                device_info = device_infos.get(part)
+                if device_info is None:
+                    # create device info if not already in dict
+                    device_items = {k: v for k, v in filtered_items.items() if k.split('.')[2] == 'device_info'}
+                    device_info = DeviceInfo(name = device_items['name'], 
+                                            configuration_url = device_items['configuration_url'], 
+                                            identifiers = device_items['identifiers'], 
+                                            model = device_items['model'],
+                                            manufacturer = device_items['manufacturer'],
+                                            sw_version = device_items['sw_version'])
+                    device_infos[part] = device_info
+
+                for key, value in filtered_items.items():
+                    sensor = get_sensor(key, value, device_info)
+                    publish(sensor, value)
+
+        i = i+1
+        time.sleep(1)
+
+    # Disconnect from the broker
+    logging.info("Stopping HA-MQTT sink")
+
+def get_sensor(name, value, device_info):
+    global sensors
+    sensor = sensors.get(name)
+    if (sensor is None):
+        # create sensor if not already in dict
+        if isinstance(value, tuple):
+            unit = value[1]
+        sensor_info = SensorInfo(unit_of_measurement = unit, 
+                                name = ".".join(name.split(".")[2:]), 
+                                device_class = None,
+                                unique_id = name, 
+                                device = device_info)
+        sensor = Sensor(Settings(mqtt = mqtt_settings, entity = sensor_info))
+        sensors[name] = sensor 
+    return sensor
+
+def publish(sensor, value):
+    publish_value = value 
+    if isinstance(value, tuple):
+        publish_value = value[0]
+    sensor.set_state(publish_value)
+
+def my_callback(key, value):
+    sensor = sensors.get(key)
+    if sensor is not None:
+        publish(sensor, value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 ]
 dependencies = [
     "requests ~=2.29.0",
-    "paho-mqtt ~=1.6.1"
+    "paho-mqtt ~=1.6.1",
+    "ha_mqtt_discoverable >=0.8",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This directly uses a home assistant mqtt publication library, apparently to make sensor integration in ha automatic. Didn't try that part myself yet, feedback welcome.