### PR TITLE
add plugin for sma ev charger

### DIFF
--- a/plugins/sources/EVCharger/README.md
+++ b/plugins/sources/EVCharger/README.md
@@ -1,0 +1,167 @@
+# SMA EV Carger Source Plugin
+
+The EV Charger source plugin is a SMAHub source plugin that retrieves data from a SMA EV Charger inverter using its built-in HTTP API. The plugin periodically polls the inverter for data and forwards the data to SMAHub for further processing.
+
+## Configuration
+
+The configuration file for the EV Charger source plugin is located in the `config` directory and has the following format:
+
+```ini
+[plugin]
+enabled = true
+
+[server]
+address = 192.168.0.2
+username = user
+protocol = https
+verifyTls = false
+password = pwd
+updateFreq = 2
+sensorPrefix = EV Charger.
+```
+
+To enable the EV Charger source plugin, set `enabled` to `true`. Update the `address`, `username`, and `password` fields to match the EV Charger inverter's IP address and credentials. Set the `updateFreq` to the desired update frequency (in seconds). Update the `sensorPrefix` to match the desired prefix for the sensors in the SMAHub.
+
+## Environment Variables
+
+The EV Charger source plugin can also be configured using the following environment variables:
+
+- `EVCHARGER_ENABLED`: Set to `true` to enable the plugin.
+- `EVCHARGER_ADDRESS`: The IP address of the EV Charger inverter.
+- `EVCHARGER_PROTOCOL`: Communication protocol to use, must be either http or https.
+- `EVCHARGER_VERIFYTLS`: Check validity of https (secure) connection, either `true` or `false`.
+- `EVCHARGER_USER`: The username for the EV Charger inverter.
+- `EVCHARGER_PASSWORD`: The password for the EV Charger inverter.
+- `EVCHARGER_UPDATEFREQ`: The update frequency (in seconds).
+- `EVCHARGER_PREFIX`: The prefix to use for the sensors in the SMAHub.
+
+## How It Works
+
+The EV Charger source plugin starts by logging into the EV Charger inverter's HTTP API using the provided credentials. Once logged in, the plugin retrieves the device information and stores it.
+
+The plugin then enters a loop where it periodically polls the inverter for data using the `/api/v1/measurements/live` endpoint. The retrieved data is then forwarded to SMAHub using the `add_data` function, which includes the sensor prefix and the sensor key (e.g., `EV Charger.power`). The forwarded data can then be consumed by SMAHub and its sink plugins.
+
+When the plugin is running, you should see the EV Charger data being received and forwarded to SMAHub in the logs.
+
+Note: Ensure that your EV Charger inverter and the SMAHub server are on the same network and that the inverter's HTTP API is accessible.
+
+---
+
+## Home Assistant MQTT sensor configuration
+
+This is a list of Home Assistant MQTT sensor definitions to add to `configuration.yaml` (mqtt: section). This makes all data collected by this plugin available in Home Assistant, published via the smahub MQTT sink plugin. This list can be (re)created using the smahub gen_ha_sensors plugin.
+Important: You have to replace "<SERIAL>" with the serial number of the device you are monitoring!
+
+```yaml
+- name: EVCHARGER_<SERIAL>_device_info_name
+  state_topic: "EVCharger/<SERIAL>/device_info/name"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_device_info_configuration_url
+  state_topic: "EVCharger/<SERIAL>/device_info/configuration_url"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_device_info_identifiers
+  state_topic: "EVCharger/<SERIAL>/device_info/identifiers"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_device_info_model
+  state_topic: "EVCharger/<SERIAL>/device_info/model"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_device_info_manufacturer
+  state_topic: "EVCharger/<SERIAL>/device_info/manufacturer"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_device_info_sw_version
+  state_topic: "EVCharger/<SERIAL>/device_info/sw_version"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_GridMs_A_phsA
+  state_topic: "EVCharger/<SERIAL>/GridMs/A/phsA"
+  unit_of_measurement: "A"
+  device_class: "current"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_A_phsB
+  state_topic: "EVCharger/<SERIAL>/GridMs/A/phsB"
+  unit_of_measurement: "A"
+  device_class: "current"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_A_phsC
+  state_topic: "EVCharger/<SERIAL>/GridMs/A/phsC"
+  unit_of_measurement: "A"
+  device_class: "current"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_Hz
+  state_topic: "EVCharger/<SERIAL>/GridMs/Hz"
+  unit_of_measurement: "Hz"
+  device_class: "frequency"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_PhV_phsA
+  state_topic: "EVCharger/<SERIAL>/GridMs/PhV/phsA"
+  unit_of_measurement: "V"
+  device_class: "voltage"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_PhV_phsB
+  state_topic: "EVCharger/<SERIAL>/GridMs/PhV/phsB"
+  unit_of_measurement: "V"
+  device_class: "voltage"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_PhV_phsC
+  state_topic: "EVCharger/<SERIAL>/GridMs/PhV/phsC"
+  unit_of_measurement: "V"
+  device_class: "voltage"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_PhV_phsC2A
+  state_topic: "EVCharger/<SERIAL>/GridMs/PhV/phsC2A"
+  unit_of_measurement: "V"
+  device_class: "voltage"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_TotA
+  state_topic: "EVCharger/<SERIAL>/GridMs/TotA"
+  unit_of_measurement: "A"
+  device_class: "current"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_TotPF
+  state_topic: "EVCharger/<SERIAL>/GridMs/TotPF"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_GridMs_TotVA
+  state_topic: "EVCharger/<SERIAL>/GridMs/TotVA"
+  unit_of_measurement: "VA"
+  device_class: "apparent_power"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_GridMs_TotVAr
+  state_topic: "EVCharger/<SERIAL>/GridMs/TotVAr"
+  unit_of_measurement: "var"
+  device_class: "reactive_power"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_InOut_GI1
+  state_topic: "EVCharger/<SERIAL>/InOut/GI1"
+  icon: "mdi:border-all"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotWhIn
+  state_topic: "EVCharger/<SERIAL>/Metering/GridMs/TotWhIn"
+  unit_of_measurement: "Wh"
+  device_class: "energy"
+  state_class: "total_increasing"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotWhIn_ChaSta
+  state_topic: "EVCharger/<SERIAL>/Metering/GridMs/TotWhIn/ChaSta"
+  unit_of_measurement: "Wh"
+  device_class: "energy"
+  state_class: "total_increasing"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotkWhIn
+  state_topic: "EVCharger/<SERIAL>/Metering/GridMs/TotWhIn"
+  unit_of_measurement: kWh
+  device_class: energy
+  state_class: total_increasing
+  value_template: "{{ value | multiply(0.001) }}"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotkWhIn_ChaSta
+  state_topic: EVCharger/<SERIAL>/Metering/GridMs/TotWhIn/ChaSta"
+  unit_of_measurement: kWh
+  device_class: energy
+  state_class: total_increasing
+  value_template: "{{ value | multiply(0.001) }}"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotWIn
+  state_topic: "EVCharger/<SERIAL>/Metering/GridMs/TotWIn"
+  unit_of_measurement: "W"
+  device_class: "power"
+  state_class: "measurement"
+- name: EVCHARGER_<SERIAL>_Metering_GridMs_TotWIn
+  state_topic: "EVCharger/<SERIAL>/Metering/GridMs/TotWIn/ChaSta"
+  unit_of_measurement: "W"
+  device_class: "power"
+  state_class: "measurement"
+```

--- a/plugins/sources/EVCharger/evcharger.conf
+++ b/plugins/sources/EVCharger/evcharger.conf
@@ -1,0 +1,11 @@
+[plugin]
+enabled = false
+
+[server]
+address = 127.0.0.1
+username = user
+password = pwd
+protocol = https
+verifyTls = false
+updateFreq = 2
+sensorPrefix = EVCharger.

--- a/plugins/sources/EVCharger/evcharger.py
+++ b/plugins/sources/EVCharger/evcharger.py
@@ -1,0 +1,153 @@
+'''
+This code is adapted from https://github.com/littleyoda/Home-Assistant-Tripower-X-MQTT
+Thank you littleyoda!
+'''
+import logging
+import os
+import time
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from utils.smahelpers import parameter_unit, isfloat
+
+
+def env_vars(config):
+    if os.environ.get('EVCHARGER_ENABLED'):
+        config['plugin']['enabled'] = os.environ.get('EVCHARGER_ENABLED')
+    if os.environ.get('EVCHARGER_ADDRESS'):
+        config['server']['address'] = os.environ.get('EVCHARGER_ADDRESS')
+    if os.environ.get('EVCHARGER_PROTOCOL'):
+        config['server']['protocol'] = os.environ.get('EVCHARGER_PROTOCOL')
+    if os.environ.get('EVCHARGER_VERIFYTLS'):
+        config['server']['verifyTls'] = os.environ.get('EVCHARGER_VERIFYTLS')
+    if os.environ.get('EVCHARGER_USER'):
+        config['server']['username'] = os.environ.get('EVCHARGER_USER')
+    if os.environ.get('EVCHARGER_PASSWORD'):
+        config['server']['password'] = os.environ.get('EVCHARGER_PASSWORD')
+    if os.environ.get('EVCHARGER_UPDATEFREQ'):
+        config['server']['updateFreq'] = int(os.environ.get('EVCHARGER_UPDATEFREQ'))
+    if os.environ.get('EVCHARGER_PREFIX'):
+        config['server']['sensorPrefix'] = os.environ.get('EVCHARGER_PREFIX')
+
+def execute(config, add_data, dostop):
+    env_vars(config)
+
+    if config.get('plugin', 'enabled').lower() != 'true':
+        logging.info("EV Charger plugin disabled")
+        return
+
+    logging.info("Starting EV Chargersource")
+
+    # set up retry and backoff for connection
+    session = requests.Session()
+    retry = Retry(connect=3, backoff_factor=0.5)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+
+    loginurl = f"{config.get('server','protocol')}://{config.get('server','address')}/api/v1/token"
+    postdata = {'grant_type': 'password',
+                'username': config.get('server', 'username'),
+                'password': config.get('server', 'password'),
+                }
+    verify_tls = config.get('server', 'verifyTls').lower() == 'true'
+
+    if not verify_tls:
+        requests.packages.urllib3.disable_warnings()
+
+    # Login & Extract Access-Token
+    try:
+        response = session.post(loginurl, data=postdata, timeout=5, verify=verify_tls)
+    except requests.exceptions.ConnectTimeout as e:
+        logging.fatal(f"Charger not reachable via HTTP: {config.get('server', 'address')}")
+        return
+    except requests.exceptions.ConnectionError as e:
+        logging.fatal(f"Charger connection error: {e.args[0]}")
+        return
+
+    if ("Content-Length" in response.headers and response.headers["Content-Length"] == '0'):
+        logging.fatal("Username or Password wrong")
+        return
+    if (404 == response.status_code):
+        logging.fatal(f"HTTP connection to {config.get('server', 'address')} refused (status 404)")
+        return
+
+    token = response.json()["access_token"]
+    headers = {"Authorization": "Bearer " + token}
+
+    # Request Device Info
+    url = f"{config.get('server','protocol')}://{config.get('server','address')}/api/v1/plants/Plant:1/devices/IGULD:SELF"
+    response = session.get(url, headers=headers, verify=verify_tls)
+    dev = response.json()
+
+    DeviceInfo = {}
+    DeviceInfo['name'] = dev['product']
+    DeviceInfo['configuration_url'] = f"{config.get('server','protocol')}://{config.get('server', 'address')}"
+    DeviceInfo['identifiers'] = dev['serial']
+    DeviceInfo['model'] = f"{dev['vendor']}-{dev['product']}"
+    DeviceInfo['manufacturer'] = dev['vendor']
+    DeviceInfo['sw_version'] = dev['firmwareVersion']
+
+    time.sleep(1)
+
+    while not dostop():
+        for key, value in DeviceInfo.items():
+            dname = f"{config.get('server', 'sensorPrefix')}{DeviceInfo['identifiers']}.device_info.{key}"
+            logging.debug(dname+': ' + value)
+            add_data(dname, value)
+
+        try:
+            url = f"{config.get('server','protocol')}://{config.get('server', 'address')}/api/v1/measurements/live"
+            response = session.post(url, headers=headers, data='[{"componentId":"IGULD:SELF"}]', verify=verify_tls)
+
+            # Check if a new acccess token is neccesary (TODO use refresh token)
+            if (response.status_code == 401):
+                logging.info(f"Got {response.status_code} - trying reauth")
+                response = requests.post(loginurl, data=postdata, verify=verify_tls)
+                token = response.json()['access_token']
+                headers = {"Authorization": "Bearer " + token}
+                continue
+
+            data = response.json()
+
+            for d in data:
+                # name is the generic parameter/measurement name
+                name = f"{d['channelId'].replace('Measurement.','').replace('[]', '')}"
+                # dname is name, prefixed with device prefix and serial number
+                dname = f"{config.get('server', 'sensorPrefix')}{DeviceInfo['identifiers']}.{name}"
+                if "value" in d['values'][0]:
+                    v = d['values'][0]['value']
+                    if isfloat(v):
+                        v = round(v, 2)
+                    unit = parameter_unit(name)
+                    if unit:
+                        add_data(dname, (v, unit))
+                    else:
+                        add_data(dname, v)
+
+                elif "values" in d['values'][0]:
+                    for idx in range(0, len(d['values'][0]['values'])):
+                        v = d['values'][0]['values'][idx]
+                        if isfloat(v):
+                            v = round(v, 2)
+                        idxname = dname + "." + str(idx + 1)
+                        unit = parameter_unit(name)
+                        if unit:
+                            add_data(idxname, (v, unit))
+                        else:
+                            add_data(idxname, v)
+                else:
+                    logging.debug(f"value of {name} is currently not availably (nighttime?)")
+                    pass
+
+            time.sleep(int(config.get('server', 'updateFreq')))
+
+        except TimeoutError:
+            logging.warning(f"Got TimeoutError - retrying")
+            pass
+
+        except Exception as e:
+            logging.error(f"Got error {e} - retrying")
+            pass
+
+    logging.info("Stopping EV Charger source")


### PR DESCRIPTION
That was easy, the SMA Charger 22kw is also running ennexOS and the data returned is quite similar to that of the Tripower X

Tested locally, and worked fine, I hope I didn't miss anything important.

Sample Output:
```
Key: Test.EVCharger.SERIAL.device_info.name, Value: EVC22-3AC-10
Key: Test.EVCharger.SERIAL.device_info.configuration_url, Value: https://10.0.0.90
Key: Test.EVCharger.SERIAL.device_info.identifiers, Value: SERIAL
Key: Test.EVCharger.SERIAL.device_info.model, Value: SMA-EVC22-3AC-10
Key: Test.EVCharger.SERIAL.device_info.manufacturer, Value: SMA
Key: Test.EVCharger.SERIAL.device_info.sw_version, Value: 1.2.23.R
Key: Test.EVCharger.SERIAL.ChaSess.WhIn, Value: 0
Key: Test.EVCharger.SERIAL.Chrg.ModSw, Value: 4718
Key: Test.EVCharger.SERIAL.GridMs.A.phsA, Value: (0, 'A')
Key: Test.EVCharger.SERIAL.GridMs.A.phsB, Value: (0, 'A')
Key: Test.EVCharger.SERIAL.GridMs.A.phsC, Value: (0, 'A')
Key: Test.EVCharger.SERIAL.GridMs.Hz, Value: (50, 'Hz')
Key: Test.EVCharger.SERIAL.GridMs.PhV.phsA, Value: (238.9, 'V')
Key: Test.EVCharger.SERIAL.GridMs.PhV.phsB, Value: (241.2, 'V')
Key: Test.EVCharger.SERIAL.GridMs.PhV.phsC, Value: (240.6, 'V')
Key: Test.EVCharger.SERIAL.GridMs.TotPF, Value: 1
Key: Test.EVCharger.SERIAL.GridMs.TotVA, Value: (0, 'VA')
Key: Test.EVCharger.SERIAL.GridMs.TotVAr, Value: (0, 'var')
Key: Test.EVCharger.SERIAL.InOut.GI1, Value: 0
Key: Test.EVCharger.SERIAL.Metering.GridMs.TotWIn, Value: 0
Key: Test.EVCharger.SERIAL.Metering.GridMs.TotWIn.ChaSta, Value: 0
Key: Test.EVCharger.SERIAL.Metering.GridMs.TotWhIn, Value: 2342
Key: Test.EVCharger.SERIAL.Metering.GridMs.TotWhIn.ChaSta, Value: 2342
Key: Test.EVCharger.SERIAL.Operation.EVeh.ChaStt, Value: 200111
Key: Test.EVCharger.SERIAL.Operation.EVeh.Health, Value: 307
Key: Test.EVCharger.SERIAL.Operation.Evt.Msg, Value: 302
Key: Test.EVCharger.SERIAL.Operation.Health, Value: 307
Key: Test.EVCharger.SERIAL.Wl.AcqStt, Value: 3369
Key: Test.EVCharger.SERIAL.Wl.ConnStt, Value: 307
Key: Test.EVCharger.SERIAL.Wl.SigPwr, Value: (-1, '%')
Key: Test.EVCharger.SERIAL.Wl.SoftAcsConnStt, Value: 308
```


I also changed the unit of the TotWh entities from 'kWh' to 'Wh' and added an additional 'TotkWh' entities with the conversion from 'kWh' to 'Wh' in the Homeassistant Sensor Configration.

Something that maybe should also be changed in the TripowerX plugin (as I got wrong readings with the default example).