### PR TITLE
Update freq and traffic

### DIFF
--- a/plugins/sinks/ha_mqtt/ha_mqtt.py
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.py
@@ -93,7 +93,7 @@ def execute(config, get_items, register_callback, do_stop):
 
 
 def get_item_by_key(list_of_dicts, target_key):
-    return next((item for item in list_of_dicts if item['key'] == target_key), None)
+    return next((item for item in list_of_dicts if item['key'] == target_key and item['enabled'] == "true"), None)
 
 
 def get_sensor(name, device_info):
@@ -111,7 +111,7 @@ def get_sensor(name, device_info):
         result = get_item_by_key(get_sensor_dict(sensors_dict), key)
 
         if result is None:
-            logging.error(f"HA-MQTT sensor definition for {key} not found")
+            logging.debug(f"HA-MQTT sensor definition for {key} not found or disabled")
             return None
             
         sensor_info = SensorInfo(unique_id=name,

--- a/plugins/sources/SHM2/shm2.conf
+++ b/plugins/sources/SHM2/shm2.conf
@@ -1,5 +1,6 @@
 [plugin]
 enabled = true
 
-[server]
+[behavior]
+updateFreq = 2
 sensorPrefix = SHM2.

--- a/plugins/sources/TripowerX/tripowerx.py
+++ b/plugins/sources/TripowerX/tripowerx.py
@@ -164,26 +164,31 @@ SENSORS_TRIPOWERX = [
     # device info
     {
         'key': "device_info.name",
+        'enabled': "true",
         'name': "Device name",
         'entity_category': "diagnostic",
     },
     {
         'key': "device_info.identifiers",
+        'enabled': "true",
         'name': "Device serial",
         'entity_category': "diagnostic",
     },
     {
         'key': "device_info.model",
+        'enabled': "true",
         'name': "Device model",
         'entity_category': "diagnostic",
     },
     {
         'key': "device_info.manufacturer",
+        'enabled': "true",
         'name': "Device manufacturer",
         'entity_category': "diagnostic",
     },
     {
         'key': "device_info.sw_version",
+        'enabled': "true",
         'name': "Device SW version",
         'entity_category': "diagnostic",
     },
@@ -191,152 +196,185 @@ SENSORS_TRIPOWERX = [
     # configuration and status data
     {
         'key': "GridGuard.Cntry",
+        'enabled': "true",
         'name': "Country standard set",
         'suggested_display_precision': 2,
     },
     {
         'key': "GridMs.TotPFEEI",
+        'enabled': "true",
         'name': "EEI displacement power factor",
         'suggested_display_precision': 2,
     },
     {
         'key': "GridMs.TotPFExt",
+        'enabled': "true",
         'name': "Excitation type of cos φ",
         'suggested_display_precision': 2,
     },
     {
         'key': "GridMs.TotPFPrc",
+        'enabled': "true",
         'name': "Displacement power factor",
         'suggested_display_precision': 2,
     },
     {
         'key': "InOut.GI1",
+        'enabled': "true",
         'name': "Digital group input",
         'suggested_display_precision': 2,
     },
     {
         'key': "Inverter.VArModCfg.PFCtlVolCfg.Stt",
+        'enabled': "true",
         'name': "cos φ(V), status",
         'suggested_display_precision': 2,
     },
         {
         'key': "Operation.BckStt",
+        'enabled': "true",
         'name': "Backup mode status",
     },
     {
         'key': "Operation.DrtStt",
+        'enabled': "true",
         'name': "Reason for derating",
     },
     {
         'key': "Operation.Evt.Dsc",
+        'enabled': "true",
         'name': "Fault correction measure",
     },
     {
         'key': "Operation.Evt.Msg",
+        'enabled': "true",
         'name': "Message",
     },
     {
         'key': "Operation.EvtCntIstl",
+        'enabled': "true",
         'name': "Number of events for installer",
     },
     {
         'key': "Operation.EvtCntUsr",
+        'enabled': "true",
         'name': "Number of events for user",
     },
     {
         'key': "Operation.Evt.EvtNo",
+        'enabled': "true",
         'name': "Current event number for manufacturer",
     },
     {
         'key': "Operation.GriSwCnt",
+        'enabled': "true",
         'name': "Number of grid connections",
     },
     {
         'key': "Operation.GriSwStt",
+        'enabled': "true",
         'name': "Grid relay/contactor",
     },
     {
         'key': "Operation.Health",
+        'enabled': "true",
         'name': "Condition",
     },
     {
         'key': "Operation.OpStt",
+        'enabled': "true",
         'name': "General operating status",
     },
     {
         'key': "Operation.HealthStt.Ok",
+        'enabled': "true",
         'name': "Nominal power in Ok Mode",
         'unit_of_measurement': "kW",
     },
     {
         'key': "Operation.PvGriConn",
+        'enabled': "true",
         'name': "Plant mains connection",
     },
     {
         'key': "Operation.RstrLokStt",
+        'enabled': "true",
         'name': "Block status",
     },
     {
         'key': "Operation.RunStt",
+        'enabled': "true",
         'name': "Operating status",
     },
     {
         'key': "Operation.StandbyStt",
+        'enabled': "true",
         'name': "Standby status",
     },
     {
         'key': "Operation.VArCtl.VArModAct",
+        'enabled': "true",
         'name': "Active reactive power range",
         'suggested_display_precision': 2,
     },
     {
         'key': "Operation.VArCtl.VArModStt",
+        'enabled': "true",
         'name': "Active reactive power behavior",
         'suggested_display_precision': 2,
     },
     {
         'key': "Operation.WMaxLimSrc",
+        'enabled': "true",
         'name': "Source of maximum active power setpoint",
         'suggested_display_precision': 2,
     },
     {
         'key': "Operation.WMinLimSrc",
+        'enabled': "true",
         'name': "Source of minimum active power setpoint",
         'suggested_display_precision': 2,
     },
     {
         'key': "SunSpecSig.SunSpecTx",
+        'enabled': "true",
         'name': "SunSpec life sign",
         'suggested_display_precision': 2,
     },
     {
         'key': "Upd.Stt",
+        'enabled': "true",
         'name': "Status of the firmware update",
         'suggested_display_precision': 2,
     },
     {
         'key': "WebConn.Stt",
+        'enabled': "true",
         'name': "Status of the Webconnect functionality",
         'suggested_display_precision': 2,
     },
     {
         'key': "Wl.ConnStt",
+        'enabled': "true",
         'name': "Wi-Fi connection status",
         'suggested_display_precision': 2,
     },
     {
         'key': "Wl.SigPwr",
+        'enabled': "true",
         'name': "Signal strength of the selected network",
         'suggested_display_precision': 2,
         'unit_of_measurement': "%",
     },
     {
         'key': "Setpoint.PlantControl.InOut.DigOut",
+        'enabled': "true",
         'name': "Digital output",
         'suggested_display_precision': 2,
     },
     {
         'key': "Operation.HealthStt.Alm",
+        'enabled': "true",
         'name': "Nominal power in Fault Mode",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -344,6 +382,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Operation.HealthStt.Wrn",
+        'enabled': "true",
         'name': "Nominal power in Warning Mode",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -353,6 +392,7 @@ SENSORS_TRIPOWERX = [
     # string-specific measurements
     {
         'key': "Coolsys.Inverter.TmpVal.1",
+        'enabled': "true",
         'name': "Inverter temperature string 1",
         'state_class': "measurement",
         'suggested_display_precision': 2,
@@ -362,6 +402,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Coolsys.Inverter.TmpVal.2",
+        'enabled': "true",
         'name': "Inverter temperature string 2",
         'state_class': "measurement",
         'suggested_display_precision': 2,
@@ -371,6 +412,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Coolsys.Inverter.TmpVal.3",
+        'enabled': "true",
         'name': "Inverter temperature string 3",
         'state_class': "measurement",
         'suggested_display_precision': 2,
@@ -380,6 +422,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Amp.1",
+        'enabled': "true",
         'name': "DC current input string 1",
         'state_class': "total_increasing",
         'suggested_display_precision': 2,
@@ -389,6 +432,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Amp.2",
+        'enabled': "true",
         'name': "DC current input string 2",
         'state_class': "total_increasing",
         'suggested_display_precision': 2,
@@ -398,6 +442,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Amp.3",
+        'enabled': "true",
         'name': "DC current input string 3",
         'state_class': "total_increasing",
         'suggested_display_precision': 2,
@@ -408,6 +453,7 @@ SENSORS_TRIPOWERX = [
 
     {
         'key': "DcMs.Vol.1",
+        'enabled': "true",
         'name': "DC voltage input string 1",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -416,6 +462,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Vol.2",
+        'enabled': "true",
         'name': "DC voltage input string 2",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -424,6 +471,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Vol.3",
+        'enabled': "true",
         'name': "DC voltage input string 3",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -432,6 +480,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Watt.1",
+        'enabled': "true",
         'name': "DC power input string 1",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -441,6 +490,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Watt.2",
+        'enabled': "true",
         'name': "DC power input string 2",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -450,6 +500,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "DcMs.Watt.3",
+        'enabled': "true",
         'name': "DC power input string 3",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -461,6 +512,7 @@ SENSORS_TRIPOWERX = [
     # global measurements
     {
         'device_class': "current",
+        'enabled': "false",
         'icon': "mdi:current-ac",
         'key': "GridMs.A.phsA",
         'name': "Phase 1 grid current",
@@ -470,6 +522,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'device_class': "current",
+        'enabled': "false",
         'icon': "mdi:current-ac",
         'key': "GridMs.A.phsB",
         'name': "Phase 1 grid current",
@@ -479,6 +532,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'device_class': "current",
+        'enabled': "false",
         'icon': "mdi:current-ac",
         'key': "GridMs.A.phsC",
         'name': "Phase 3 grid current",
@@ -488,6 +542,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.Hz",
+        'enabled': "true",
         'name': "Grid frequency",
         'suggested_display_precision': 2,
         'unit_of_measurement': "Hz",
@@ -497,6 +552,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsA",
+        'enabled': "false",
         'name': "Phase 1 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -505,6 +561,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsA2B",
+        'enabled': "false",
         'name': "Phase 1to2 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -513,6 +570,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsB",
+        'enabled': "false",
         'name': "Phase 2 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -521,6 +579,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsB2C",
+        'enabled': "false",
         'name': "Phase 2to3 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -529,6 +588,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsC",
+        'enabled': "false",
         'name': "Phase 3 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -537,6 +597,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.PhV.phsC2A",
+        'enabled': "false",
         'name': "Phase 3to1 grid voltage",
         'suggested_display_precision': 2,
         'device_class': "voltage",
@@ -545,6 +606,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'device_class': "current",
+        'enabled': "true",
         'icon': "mdi:current-ac",
         'key': "GridMs.TotA",
         'name': "Grid current",
@@ -554,6 +616,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.TotVA",
+        'enabled': "false",
         'name': "Apparent power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VA",
@@ -563,6 +626,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.TotVAr",
+        'enabled': "false",
         'name': "Reactive power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VAR",
@@ -572,6 +636,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.TotW",
+        'enabled': "true",
         'name': "Power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -581,6 +646,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.TotW.Pv",
+        'enabled': "true",
         'name': "Power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -590,6 +656,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VA.phsA",
+        'enabled': "false",
         'name': "Phase 1 apparent power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VA",
@@ -599,6 +666,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VA.phsB",
+        'enabled': "false",
         'name': "Phase 2 apparent power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VA",
@@ -608,6 +676,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VA.phsC",
+        'enabled': "false",
         'name': "Phase 3 apparent power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VA",
@@ -617,6 +686,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VAr.phsA",
+        'enabled': "false",
         'name': "Phase 1 reactive power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VAR",
@@ -626,6 +696,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VAr.phsB",
+        'enabled': "false",
         'name': "Phase 2 reactive power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VAR",
@@ -635,6 +706,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.VAr.phsC",
+        'enabled': "false",
         'name': "Phase 3 reactive power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "VAR",
@@ -644,6 +716,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.W.phsA",
+        'enabled': "false",
         'name': "Phase 1 power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -653,6 +726,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.W.phsB",
+        'enabled': "false",
         'name': "Phase 2 power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -662,6 +736,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "GridMs.W.phsC",
+        'enabled': "false",
         'name': "Phase 3 power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -671,6 +746,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'device_class': "current",
+        'enabled': "false",
         'icon': "mdi:current-dc",
         'key': "Isolation.FltA",
         'name': "Residual current",
@@ -680,6 +756,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Isolation.LeakRis",
+        'enabled': "false",
         'name': "Insulation resistance",
         'suggested_display_precision': 2,
         'unit_of_measurement': "kOhm",
@@ -687,6 +764,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Metering.TotFeedTms",
+        'enabled': "true",
         'name': "Feed-in time",
         'suggested_display_precision': 2,
         'unit_of_measurement': "s",
@@ -695,6 +773,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Metering.TotOpTms",
+        'enabled': "true",
         'name': "Operating time",
         'suggested_display_precision': 2,
         'unit_of_measurement': "s",
@@ -703,6 +782,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Metering.TotWhOut",
+        'enabled': "true",
         'name': "Total yield",
         'suggested_display_precision': 2,
         'unit_of_measurement': "Wh",
@@ -712,6 +792,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Metering.TotWhOut.Pv",
+        'enabled': "true",
         'name': "Total PV yield",
         'suggested_display_precision': 2,
         'unit_of_measurement': "Wh",
@@ -721,6 +802,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "PvGen.PvW",
+        'enabled': "true",
         'name': "PV generation power",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
@@ -730,6 +812,7 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "PvGen.PvWh",
+        'enabled': "true",
         'name': "Meter count and PV gen. meter",
         'suggested_display_precision': 2,
         'unit_of_measurement': "kWh",
@@ -739,41 +822,49 @@ SENSORS_TRIPOWERX = [
     },
     {
         'key': "Setpoint.PlantControl.Inverter.WModCfg.WCtlComCfg.W",
+        'enabled': "true",
         'name': "Active power limitation by PV system control",
         'suggested_display_precision': 2,
         'unit_of_measurement': "W",
     },
     {
         'key': "Setpoint.PlantControl.Inverter.VArModCfg.PFCtlComCfg.PF",
+        'enabled': "false",
         'name': "External cos φ setpoint specification, cos φ setpoint for active power output",
         'suggested_display_precision': 4,
     },
     {
         'key': "Setpoint.PlantControl.Inverter.VArModCfg.PFCtlComCfg.PFExt",
+        'enabled': "false",
         'name': "External cos φ setpoint specification, excitation type for active power output",
     },
     {
         'key': "Setpoint.PlantControl.Inverter.VArModCfg.VArCtlComCfg.VArNom",
+        'enabled': "false",
         'name': "Standardized reactive power setpoint by system control",
         'suggested_display_precision': 2,
         'unit_of_measurement': "%",
     },
     {
         'key': "Setpoint.PlantControl.Inverter.WModCfg.WCtlComCfg.WNom",
+        'enabled': "true",
         'name': "Normalized active power limitation by PV system control",
         'suggested_display_precision': 2,
         'unit_of_measurement': "%",
     },
     {
         'key': "SunSpecSig.SunSpecTx.1",
+        'enabled': "false",
         'name': "SunSpec life sign [1]",
     },
     {
         'key': "Wl.AcqStt",
+        'enabled': "false",
         'name': "Status of Wi-Fi scan",
     },
     {
         'key': "Wl.SoftAcsConnStt",
+        'enabled': "false",
         'name': "Soft Access Point status",
     },
 ]


### PR DESCRIPTION
- add updateFreq for SHM2 plugin (will ignore/drop data frames if freq > 1sec)
- update SHM2 config section naming pattern ([server] -> [behavior])
- add 'enabled' property for SHM2 and TripowerX sensor dictionaries; 'enabled'="false" sensors will not be published by ha_mqtt