### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.6.1"
 authors = [{ name = "Daniel Krippner", email = "dk.mailbox@gmx.net" }]
 description = "Little daemon that runs plugins for collecting data from SMA PV products, and publishes to eg MQTT via other plugins."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",


### PR DESCRIPTION
Adjusting Python version as uv complained about dependencies on sync.

This was the `uv sync` output and it clearly points at a required Python version adjustment:
```bash
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.10.0,<4.0 and ha-mqtt-discoverable>=0.9.0
      depends on Python>=3.10.0,<4.0, we can conclude that ha-mqtt-discoverable>=0.9.0 cannot be used.
      And because only the following versions of ha-mqtt-discoverable are available:
          ha-mqtt-discoverable<=0.9.0
          ha-mqtt-discoverable==0.10.0
          ha-mqtt-discoverable==0.11.0
          ha-mqtt-discoverable==0.12.0
          ha-mqtt-discoverable==0.13.0
          ha-mqtt-discoverable==0.13.1
          ha-mqtt-discoverable==0.14.0
          ha-mqtt-discoverable==0.16.0
      and your project depends on ha-mqtt-discoverable>=0.9, we can conclude that your project's requirements are
      unsatisfiable.

      hint: ha-mqtt-discoverable was requested with a pre-release marker (e.g., all of:
          ha-mqtt-discoverable>0.9.0,<0.10.0
          ha-mqtt-discoverable>0.10.0,<0.11.0
          ha-mqtt-discoverable>0.11.0,<0.12.0
          ha-mqtt-discoverable>0.12.0,<0.13.0
          ha-mqtt-discoverable>0.13.0,<0.13.1
          ha-mqtt-discoverable>0.13.1,<0.14.0
          ha-mqtt-discoverable>0.14.0,<0.16.0
          ha-mqtt-discoverable>0.16.0,<1.dev0
      ), but pre-releases weren't enabled (try: `--prerelease=allow`)

      hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies
      (e.g., ha-mqtt-discoverable>=0.9.0 only supports >=3.10.0, <4.0). Consider using a more restrictive
      `requires-python` value (like >=3.10.0, <4.0).
```