### PR TITLE
Update ha_mqtt.conf

### DIFF
--- a/plugins/sinks/ha_mqtt/ha_mqtt.conf
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.conf
@@ -3,8 +3,8 @@ enabled = false
 
 [server]
 address = 192.0.2.1
-username = ""
-password = ""
+username = REPLACE_WITH_YOUR_USERNAME
+password = REPLACE_WITH_YOUR_PASSWORD
 
 [behavior]
 # this determines the number of seconds before a full republish of all collected data, even if there's been no value updates


### PR DESCRIPTION
A suggestion to make it easier to understand that you shouldn't just fill in a username / pw within quotes. Cost me over an hour to figure that one out. Sending to MQTT just didn't work with authorisation error. Feel free to adjust.
I just hope it will save others the time and effort.

An option (and best practice) could be to put all config from all modules into something like a dotenv or central configuration file ... (e.g. https://pypi.org/project/python-dotenv/).