### PR TITLE
Update ha_mqtt.py

### DIFF
--- a/plugins/sinks/ha_mqtt/ha_mqtt.py
+++ b/plugins/sinks/ha_mqtt/ha_mqtt.py
@@ -74,7 +74,7 @@ def execute(config, get_items, register_callback, do_stop):
                     # remove the leading parts of each key, just leave the last part
                     di = {k.split(".")[-1]: v for k, v in device_items.items()}
                     device_info = DeviceInfo(name=di['name'],
-                                             identifiers=di['identifiers'],
+                                             identifiers=[str(di['identifiers']),],
                                              model=di['model'],
                                              manufacturer=di['manufacturer'],
                                              sw_version=di['sw_version'])


### PR DESCRIPTION
Fixing Sunny Home Manager 2 list issue.

This is the issue I encountered:
```
2024-11-05 13:06:52 INFO     Starting smahub 1.6.1
2024-11-05 13:06:53 INFO     demo source plugin disabled
2024-11-05 13:06:53 INFO     Starting Tripower X source
2024-11-05 13:06:53 INFO     Starting SHM2 source
2024-11-05 13:06:53 INFO     EV Charger plugin disabled
2024-11-05 13:06:53 INFO     demo sink plugin disabled
2024-11-05 13:06:53 INFO     Starting HA-MQTT sink
2024-11-05 13:06:53 INFO     Starting MQTT sink
2024-11-05 13:06:53 INFO     gen_ha_sensors sink plugin disabled
2024-11-05 13:06:55 ERROR    An unhandled error occurred in a worker thread, the application will exit: 2 validation errors for DeviceInfo
identifiers.list[str]
  Input should be a valid list [type=list_type, input_value=3015993579, input_type=int]
    For further information visit https://errors.pydantic.dev/2.9/v/list_type
identifiers.str
  Input should be a valid string [type=string_type, input_value=3015993579, input_type=int]
    For further information visit https://errors.pydantic.dev/2.9/v/string_type
2024-11-05 13:06:55 INFO     Exiting...
2024-11-05 13:06:56 INFO     Stopping SHM2 source
2024-11-05 13:06:57 INFO     Stopping Tripower X source
2024-11-05 13:06:59 CRITICAL MQTT broker unknown error: timed out, rethrowing exception
```